### PR TITLE
Add DDTree and Bet-Optimal Drafting (BOD)

### DIFF
--- a/dflash_mlx/__init__.py
+++ b/dflash_mlx/__init__.py
@@ -2,18 +2,24 @@
 
 from .adapters import LoadedTargetModel, adapter_for_model_type, load_target_model
 from .api import DFlashGenerator, DFlashResult
+from .ddtree import DDTreeConfig, DraftTree, build_draft_tree, ddtree_generate, walk_tree
 from .draft import DFlashDraftModel, load_draft_model
 from .runtime import dflash_generate, longest_prefix_match, sample_tokens
 
 __all__ = [
+    "DDTreeConfig",
     "DFlashGenerator",
     "DFlashResult",
     "DFlashDraftModel",
+    "DraftTree",
     "LoadedTargetModel",
     "adapter_for_model_type",
+    "build_draft_tree",
     "dflash_generate",
+    "ddtree_generate",
     "load_draft_model",
     "load_target_model",
     "longest_prefix_match",
     "sample_tokens",
+    "walk_tree",
 ]

--- a/dflash_mlx/api.py
+++ b/dflash_mlx/api.py
@@ -8,6 +8,7 @@ import mlx.core as mx
 from mlx_lm.generate import wired_limit
 
 from .adapters import LoadedTargetModel, load_target_model
+from .ddtree import DDTreeConfig, ddtree_generate
 from .draft import DFlashDraftModel, load_draft_model, maybe_quantize_draft_model
 from .runtime import dflash_generate
 
@@ -71,23 +72,44 @@ class DFlashGenerator:
         reset_peak_memory: bool = True,
         skip_special_tokens: bool = False,
         profile: bool = False,
+        ddtree_budget: int = 64,
+        ddtree_use_bod: bool = False,
+        use_bod: bool = False,
     ) -> DFlashResult:
         with wired_limit(self.target.model):
             if reset_peak_memory:
                 mx.reset_peak_memory()
-            output_tokens, metrics = dflash_generate(
-                target=self.target,
-                draft=self.draft,
-                prompt_tokens=prompt_tokens,
-                max_new_tokens=max_new_tokens,
-                temperature=temperature,
-                stop_token_ids=self.target.stop_token_ids(),
-                layer_ids=self.draft.target_layer_ids,
-                speculative_tokens=speculative_tokens,
-                verify_mode=verify_mode,
-                verify_chunk_size=verify_chunk_size,
-                profile=profile,
-            )
+            if verify_mode == "ddtree":
+                ddtree_cfg = DDTreeConfig(
+                    budget=ddtree_budget,
+                    use_bod=ddtree_use_bod,
+                    profile=profile,
+                )
+                output_tokens, metrics = ddtree_generate(
+                    target=self.target,
+                    draft=self.draft,
+                    prompt_tokens=prompt_tokens,
+                    max_new_tokens=max_new_tokens,
+                    temperature=temperature,
+                    stop_token_ids=self.target.stop_token_ids(),
+                    layer_ids=self.draft.target_layer_ids,
+                    config=ddtree_cfg,
+                )
+            else:
+                output_tokens, metrics = dflash_generate(
+                    target=self.target,
+                    draft=self.draft,
+                    prompt_tokens=prompt_tokens,
+                    max_new_tokens=max_new_tokens,
+                    temperature=temperature,
+                    stop_token_ids=self.target.stop_token_ids(),
+                    layer_ids=self.draft.target_layer_ids,
+                    speculative_tokens=speculative_tokens,
+                    verify_mode=verify_mode,
+                    verify_chunk_size=verify_chunk_size,
+                    profile=profile,
+                    use_bod=use_bod,
+                )
 
         generated_tokens = output_tokens[metrics["num_input_tokens"] :]
         text = self.target.tokenizer.decode(
@@ -112,6 +134,9 @@ class DFlashGenerator:
         reset_peak_memory: bool = True,
         skip_special_tokens: bool = False,
         profile: bool = False,
+        ddtree_budget: int = 64,
+        ddtree_use_bod: bool = False,
+        use_bod: bool = False,
     ) -> DFlashResult:
         return self.generate_from_tokens(
             prompt_tokens=self.encode_prompt(prompt_text),
@@ -123,4 +148,7 @@ class DFlashGenerator:
             reset_peak_memory=reset_peak_memory,
             skip_special_tokens=skip_special_tokens,
             profile=profile,
+            ddtree_budget=ddtree_budget,
+            ddtree_use_bod=ddtree_use_bod,
+            use_bod=use_bod,
         )

--- a/dflash_mlx/bet_optimal_drafting.py
+++ b/dflash_mlx/bet_optimal_drafting.py
@@ -1,0 +1,600 @@
+"""Bet-Optimal Drafting (BOD) — unified chain and tree optimizer.
+
+The draft model is a gambler. The target model is the house.
+
+BOD optimizes the gambler's bet size to maximize throughput. It supports
+two betting modes that share the same mathematical core:
+
+Chain mode (vanilla DFlash / standard speculative decoding):
+    The gambler lays down γ tokens in a line. Draft cost scales with γ,
+    verify cost is fixed. BOD picks the optimal γ.
+
+Tree mode (DDTree / tree-based speculative decoding):
+    The gambler lays down B nodes in a tree. Draft cost is fixed (one
+    diffusion pass), verify cost scales with B (tree attention). BOD
+    picks the optimal B.
+
+The math is identical — both reduce to:
+
+    T(x) = (E[tokens | x] + 1) / (c_fixed + c_scale · x)
+
+where x is the bet size (γ or B), E[tokens] is a concave increasing
+function of x, and the denominator is linear. The optimal x maximizes
+this ratio. The costs simply swap roles:
+
+    Chain: c_fixed = c_verify,  c_scale = c_draft_per_token,  x = γ
+    Tree:  c_fixed = c_draft,   c_scale = c_verify_per_node,  x = B
+
+Each mode has three optimization tiers, from cheapest to most general:
+
+Chain mode:
+    1. Verify-dominated (c_v >> c_d·γ_max): return max γ immediately.
+       The house fee dwarfs the dealing cost, so every extra card
+       amortizes the fixed overhead. One comparison, zero math. Common
+       on hybrid SSM-attention architectures (Qwen3.5).
+    2. ρ = 0 (no Markov recovery): closed-form via Lambert W.
+       FOC reduces to (u+K)·exp(−u) = 1 with K = 1 + (c_v/c_d)·|ln α|.
+       Solution: u = −W₋₁(−e⁻ᴷ) − K, asymptotic u ≈ ln K for K > 30.
+       One log, one Lambert W, no GPU. Common case for standard spec decode.
+    3. ρ > 0 (Markov recovery): fused Metal kernel sweep.
+       The unified Markov formula ea = n·ρ/d + λ·(1−α)·(1−λⁿ)/d² has
+       no known closed-form argmax. One thread per candidate γ evaluates
+       all candidates in a single GPU dispatch. Only reached with extended
+       verification schemes.
+
+Tree mode:
+    1. Draft-dominated (c_draft >> c_vpn·B_max): return max B immediately.
+       Verify per node is negligible, so always expand the tree. One
+       comparison, zero math. Common when tree attention is heavily
+       optimized or the diffusion pass is slow.
+    2. Enough observations: closed-form via Lambert W on log model.
+       E[accepted] ≈ a·ln(B) + b, fit online from observed (B, τ) pairs.
+       FOC gives B* = R / W₀(R·e^{k/a}) where R = c_draft/c_vpn.
+       One log, one Lambert W, no GPU.
+    3. Cold start (insufficient data): fused Metal kernel sweep.
+       Evaluates throughput at all candidate budgets using the default
+       log-acceptance model. One GPU dispatch.
+
+Usage (chain mode — vanilla DFlash):
+    bod = BODController(BODConfig(mode='chain'))
+    for cycle in spec_decode_loop:
+        gamma = bod.optimal_bet()
+        # ... draft gamma tokens, verify ...
+        bod.observe(bet=gamma, accepted=n_accepted, ...)
+
+Usage (tree mode — DDTree):
+    bod = BODController(BODConfig(mode='tree'))
+    for cycle in spec_decode_loop:
+        budget = bod.optimal_bet()
+        # ... build tree with budget nodes, verify ...
+        bod.observe(bet=budget, accepted=n_accepted, ...)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import mlx.core as mx
+
+
+# ---------------------------------------------------------------------------
+# Metal kernel — fused Markov throughput sweep (chain mode only)
+# ---------------------------------------------------------------------------
+
+_BOD_CHAIN_KERNEL_SOURCE = """
+    uint idx = thread_position_in_grid.x;
+
+    float alpha         = params[0];
+    float rho           = params[1];
+    float draft_per_tok = params[2];
+    float verify_cost   = params[3];
+    float min_gamma     = params[4];
+
+    float gamma = min_gamma + (float)idx;
+    float n = gamma - 1.0f;
+
+    float ea;
+    if (alpha > 0.999f) {
+        ea = n;
+    } else if (alpha < 0.001f) {
+        ea = 0.0f;
+    } else {
+        float lam = alpha - rho;
+        float d = 1.0f - lam;
+        float lam_pow_n = metal::pow(lam, n);
+        ea = n * rho / d
+           + lam * (1.0f - alpha) * (1.0f - lam_pow_n) / (d * d);
+    }
+
+    float cycle_time = draft_per_tok * gamma + verify_cost;
+    throughputs[idx] = (ea + 1.0f) / cycle_time;
+"""
+
+_bod_chain_kernel = mx.fast.metal_kernel(
+    name="bod_chain_markov",
+    input_names=["params"],
+    output_names=["throughputs"],
+    source=_BOD_CHAIN_KERNEL_SOURCE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Metal kernel — fused log-acceptance throughput sweep (tree mode)
+# ---------------------------------------------------------------------------
+
+_BOD_TREE_KERNEL_SOURCE = """
+    uint idx = thread_position_in_grid.x;
+
+    float log_slope  = params[0];
+    float log_offset = params[1];
+    float c_fixed    = params[2];
+    float c_scale    = params[3];
+    float min_bet    = params[4];
+
+    float bet = min_bet + (float)idx;
+
+    // E[tokens] + 1 = a * ln(bet) + b + 1
+    float ea_plus_1 = log_slope * metal::log(bet) + log_offset + 1.0f;
+    if (ea_plus_1 < 1.0f) ea_plus_1 = 1.0f;  // floor: at least the bonus token
+
+    float cycle_time = c_fixed + c_scale * bet;
+    throughputs[idx] = ea_plus_1 / cycle_time;
+"""
+
+_bod_tree_kernel = mx.fast.metal_kernel(
+    name="bod_tree_log",
+    input_names=["params"],
+    output_names=["throughputs"],
+    source=_BOD_TREE_KERNEL_SOURCE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BODObservation:
+    """One cycle's worth of data. Fields used depend on mode."""
+    bet: int               # γ (chain) or B (tree)
+    accepted: int          # tokens accepted this cycle
+    cycle_time_ms: float   # total wall time
+    draft_time_ms: float   # draft model time
+    verify_time_ms: float  # target model time
+    confidence: float      # draft model avg max-softmax
+
+
+@dataclass
+class BODConfig:
+    """Configuration for BOD controller.
+
+    mode='chain': optimize draft length γ (vanilla DFlash).
+    mode='tree':  optimize node budget B (DDTree).
+    """
+    mode: str = 'chain'  # 'chain' or 'tree'
+
+    # -- Bet range --
+    min_bet: int = 2
+    max_bet: int = 16     # γ_max (chain) or B_max (tree)
+
+    # -- Default costs (before enough data) --
+    default_scale_cost: float = 8.0   # c_d per token (chain) or c_vpn (tree)
+    default_fixed_cost: float = 47.0  # c_v (chain) or c_draft (tree)
+
+    # -- Observation windows --
+    acceptance_window: int = 8
+    cost_window: int = 16
+    cost_min_observations: int = 4
+    cost_min_unique_bets: int = 2
+    max_obs_age: int = 64
+
+    # -- Chain-mode Markov model --
+    confidence_weight: float = 0.3
+    rho: float = 0.0
+
+    # -- Tree-mode log acceptance model --
+    # E[accepted] ≈ log_slope * ln(B) + log_offset
+    # Estimated online from observed (B, tau) pairs.
+    # Defaults are from MATH-500 / Qwen3-8B empirical fit.
+    default_log_slope: float = 0.71
+    default_log_offset: float = 5.18
+
+    # -- Analytical fast path --
+    dominance_ratio: float = 4.0
+
+    # -- Tree-mode budget candidates --
+    # DDTree only tests powers of 2. BOD can sweep any range, but for
+    # compatibility with DDTree we default to the same set.
+    tree_budget_candidates: list[int] = field(
+        default_factory=lambda: [16, 32, 64, 128, 256, 512, 1024]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Controller
+# ---------------------------------------------------------------------------
+
+class BODController:
+    """Unified bet-size optimizer for chain and tree speculative decoding.
+
+    Chain mode fast paths:
+    1. Verify-dominated → max_bet.
+    2. ρ = 0 → Lambert W closed form.
+    3. ρ > 0 → Metal kernel sweep.
+
+    Tree mode fast paths:
+    1. Draft-dominated → max_bet (tree attention is cheap, always expand).
+    2. Enough observations → Lambert W on log acceptance model.
+    3. Fallback → Metal kernel sweep over budget candidates.
+    """
+
+    def __init__(self, cfg: BODConfig | None = None):
+        self.cfg = cfg or BODConfig()
+        self._observations: list[BODObservation] = []
+        self._cycle: int = 0
+        self._rho_estimate: float = self.cfg.rho
+
+        # Tree mode: online log-acceptance model
+        self._log_slope: float = self.cfg.default_log_slope
+        self._log_offset: float = self.cfg.default_log_offset
+
+    @property
+    def cycle(self) -> int:
+        return self._cycle
+
+    def optimal_bet(self) -> int:
+        """Return the optimal bet size for the next cycle."""
+        if self.cfg.mode == 'chain':
+            return self._optimal_chain()
+        return self._optimal_tree()
+
+    def observe(
+        self,
+        bet: int,
+        accepted: int,
+        cycle_time_ms: float,
+        draft_time_ms: float,
+        verify_time_ms: float,
+        confidence: float = 0.0,
+    ) -> None:
+        """Record what happened this cycle."""
+        self._observations.append(BODObservation(
+            bet=bet, accepted=accepted, cycle_time_ms=cycle_time_ms,
+            draft_time_ms=draft_time_ms, verify_time_ms=verify_time_ms,
+            confidence=confidence,
+        ))
+        self._cycle += 1
+        if len(self._observations) > self.cfg.max_obs_age:
+            self._observations = self._observations[-self.cfg.max_obs_age:]
+
+        if self.cfg.mode == 'tree':
+            self._update_log_model()
+
+    # -------------------------------------------------------------------
+    # Chain mode (DFlash)
+    # -------------------------------------------------------------------
+
+    def _optimal_chain(self) -> int:
+        cfg = self.cfg
+        alpha = self._estimate_alpha()
+        c_scale, c_fixed = self._estimate_costs_chain()
+
+        # Fast path 1: verify-dominated → max γ
+        if c_fixed > cfg.dominance_ratio * c_scale * cfg.max_bet:
+            return cfg.max_bet
+
+        # Fast path 2: ρ=0 → Lambert W
+        if self._rho_estimate < 1e-8:
+            return _analytical_gamma(
+                alpha, c_scale, c_fixed, cfg.min_bet, cfg.max_bet,
+            )
+
+        # General: Metal kernel sweep
+        return _chain_sweep_metal(
+            alpha, self._rho_estimate, c_scale, c_fixed,
+            cfg.min_bet, cfg.max_bet,
+        )
+
+    def _estimate_alpha(self) -> float:
+        """Confidence-weighted acceptance rate (chain mode)."""
+        w = self.cfg.confidence_weight
+        obs = self._observations
+        if not obs:
+            return 0.85
+        recent = obs[-self.cfg.acceptance_window:]
+        rates = [o.accepted / max(o.bet - 1, 1) for o in recent]
+        observed = sum(rates) / len(rates)
+        confs = [o.confidence for o in recent if o.confidence > 0]
+        conf_alpha = sum(confs) / len(confs) if confs else observed
+        blended = (1.0 - w) * observed + w * conf_alpha
+        return max(0.01, min(blended, 0.999))
+
+    def _estimate_costs_chain(self) -> tuple[float, float]:
+        """(c_scale=draft_per_tok, c_fixed=verify_cost) for chain mode."""
+        obs = self._observations
+        if len(obs) < self.cfg.cost_min_observations:
+            return self.cfg.default_scale_cost, self.cfg.default_fixed_cost
+        recent = obs[-self.cfg.cost_window:]
+        if len(set(o.bet for o in recent)) < self.cfg.cost_min_unique_bets:
+            return self.cfg.default_scale_cost, self.cfg.default_fixed_cost
+
+        c_scale = _ols_slope([float(o.bet) for o in recent],
+                             [o.draft_time_ms for o in recent])
+        c_scale = max(c_scale, 0.5)
+
+        c_fixed = _median([o.verify_time_ms for o in recent])
+        c_fixed = max(c_fixed, 1.0)
+        return c_scale, c_fixed
+
+    # -------------------------------------------------------------------
+    # Tree mode (DDTree)
+    # -------------------------------------------------------------------
+
+    def _optimal_tree(self) -> int:
+        cfg = self.cfg
+        c_scale, c_fixed = self._estimate_costs_tree()
+
+        # Fast path 1: draft-dominated → max budget
+        # (verify per node is negligible, always expand the tree)
+        if c_fixed > cfg.dominance_ratio * c_scale * cfg.max_bet:
+            return cfg.max_bet
+
+        # Fast path 2: enough data → Lambert W on log model
+        if len(self._observations) >= cfg.cost_min_observations:
+            return _analytical_budget(
+                self._log_slope, self._log_offset,
+                c_scale, c_fixed, cfg.min_bet, cfg.max_bet,
+            )
+
+        # Fallback: Metal kernel sweep over candidates
+        return _tree_sweep_metal(
+            self._log_slope, self._log_offset,
+            c_scale, c_fixed, cfg.min_bet, cfg.max_bet,
+        )
+
+    def _estimate_costs_tree(self) -> tuple[float, float]:
+        """(c_scale=verify_per_node, c_fixed=draft_cost) for tree mode.
+
+        Costs swap vs chain: verify scales with B, draft is fixed.
+        """
+        obs = self._observations
+        if len(obs) < self.cfg.cost_min_observations:
+            return self.cfg.default_scale_cost, self.cfg.default_fixed_cost
+        recent = obs[-self.cfg.cost_window:]
+        if len(set(o.bet for o in recent)) < self.cfg.cost_min_unique_bets:
+            return self.cfg.default_scale_cost, self.cfg.default_fixed_cost
+
+        # Verify cost scales with B → OLS on (B, verify_time)
+        c_scale = _ols_slope([float(o.bet) for o in recent],
+                             [o.verify_time_ms for o in recent])
+        c_scale = max(c_scale, 0.001)
+
+        # Draft cost is fixed → median of draft times
+        c_fixed = _median([o.draft_time_ms for o in recent])
+        c_fixed = max(c_fixed, 1.0)
+        return c_scale, c_fixed
+
+    def _update_log_model(self) -> None:
+        """Fit S(B) ≈ a·ln(B) + b from observed (bet, accepted) pairs."""
+        obs = self._observations
+        if len(obs) < self.cfg.cost_min_observations:
+            return
+        recent = obs[-self.cfg.cost_window:]
+        if len(set(o.bet for o in recent)) < self.cfg.cost_min_unique_bets:
+            return
+
+        # OLS on (ln(B), tau) where tau = accepted + 1
+        log_bets = [math.log(o.bet) for o in recent]
+        taus = [float(o.accepted + 1) for o in recent]
+        n = len(log_bets)
+        sx = sum(log_bets); sy = sum(taus)
+        sxx = sum(x * x for x in log_bets)
+        sxy = sum(x * y for x, y in zip(log_bets, taus))
+        denom = n * sxx - sx * sx
+        if abs(denom) < 0.001:
+            return
+        slope = (n * sxy - sx * sy) / denom
+        intercept = (sy - slope * sx) / n
+
+        # Sanity: slope should be positive (more nodes → more acceptance)
+        if slope > 0.01:
+            self._log_slope = slope
+            self._log_offset = intercept
+
+
+# ---------------------------------------------------------------------------
+# Analytical solvers (pure Python — no GPU)
+# ---------------------------------------------------------------------------
+
+def _analytical_gamma(
+    alpha: float, c_scale: float, c_fixed: float,
+    min_bet: int = 2, max_bet: int = 16,
+) -> int:
+    """Closed-form optimal γ for chain mode (ρ=0) via Lambert W.
+
+    FOC: (u + K)·exp(−u) = 1, K = 1 + (c_fixed/c_scale)·|ln α|.
+    Solution: u = −W₋₁(−e⁻ᴷ) − K, γ = u / |ln α|.
+    Asymptotic fallback u ≈ ln(K) when K > 30.
+    """
+    if alpha <= 0.001: return min_bet
+    if alpha >= 0.999: return max_bet
+    if c_scale < 1e-10: return max_bet
+
+    L = -math.log(alpha)
+    K = 1.0 + (c_fixed / c_scale) * L
+
+    if K > 30:
+        u = math.log(K)
+    else:
+        try:
+            from scipy.special import lambertw
+            import numpy as np
+            w_val = float(np.real(lambertw(-math.exp(-K), k=-1)))
+            u = -w_val - K
+        except ImportError:
+            u = math.log(K)
+
+    gamma = u / L
+    if not math.isfinite(gamma): return max_bet
+    return max(min_bet, min(int(round(gamma)), max_bet))
+
+
+def _analytical_budget(
+    log_slope: float, log_offset: float,
+    c_scale: float, c_fixed: float,
+    min_bet: int = 16, max_bet: int = 1024,
+) -> int:
+    """Closed-form optimal B for tree mode via Lambert W.
+
+    Throughput T(B) = (a·ln(B) + b + 1) / (c_fixed + c_scale·B).
+    FOC: B* = R / W₀(R · e^{k/a}), R = c_fixed/c_scale, k = b + 1 - a.
+    """
+    if c_scale < 1e-10: return max_bet
+    if log_slope < 0.01: return min_bet
+
+    a = log_slope
+    k = log_offset + 1.0 - a
+    R = c_fixed / c_scale
+
+    z = R * math.exp(k / a)
+    if not math.isfinite(z) or z <= 0:
+        return max_bet
+
+    try:
+        from scipy.special import lambertw
+        import numpy as np
+        w_val = float(np.real(lambertw(z, k=0)))
+        if w_val <= 0: return max_bet
+        B_star = R / w_val
+    except ImportError:
+        # Asymptotic: W₀(z) ≈ ln(z) - ln(ln(z)) for large z
+        ln_z = math.log(z)
+        w_approx = ln_z - math.log(ln_z) if ln_z > 1 else 1.0
+        B_star = R / w_approx
+
+    if not math.isfinite(B_star): return max_bet
+    return max(min_bet, min(int(round(B_star)), max_bet))
+
+
+# ---------------------------------------------------------------------------
+# Metal kernel sweeps
+# ---------------------------------------------------------------------------
+
+def _chain_sweep_metal(
+    alpha: float, rho: float,
+    c_scale: float, c_fixed: float,
+    min_bet: int, max_bet: int,
+) -> int:
+    """Sweep γ candidates via fused Metal kernel (chain mode, ρ > 0)."""
+    num = max_bet - min_bet + 1
+    params = mx.array(
+        [alpha, rho, c_scale, c_fixed, float(min_bet)],
+        dtype=mx.float32,
+    )
+    outputs = _bod_chain_kernel(
+        inputs=[params],
+        template=[("T", mx.float32)],
+        grid=(num, 1, 1), threadgroup=(num, 1, 1),
+        output_shapes=[(num,)], output_dtypes=[mx.float32],
+    )
+    return min_bet + int(mx.argmax(outputs[0]))
+
+
+def _tree_sweep_metal(
+    log_slope: float, log_offset: float,
+    c_scale: float, c_fixed: float,
+    min_bet: int, max_bet: int,
+) -> int:
+    """Sweep B candidates via fused Metal kernel (tree mode)."""
+    num = max_bet - min_bet + 1
+    params = mx.array(
+        [log_slope, log_offset, c_fixed, c_scale, float(min_bet)],
+        dtype=mx.float32,
+    )
+    outputs = _bod_tree_kernel(
+        inputs=[params],
+        template=[("T", mx.float32)],
+        grid=(num, 1, 1), threadgroup=(min(num, 256), 1, 1),
+        output_shapes=[(num,)], output_dtypes=[mx.float32],
+    )
+    return min_bet + int(mx.argmax(outputs[0]))
+
+
+# ---------------------------------------------------------------------------
+# Pure Python helpers
+# ---------------------------------------------------------------------------
+
+def _ols_slope(xs: list[float], ys: list[float]) -> float:
+    """OLS slope on ≤16 observations. Pure Python."""
+    n = len(xs)
+    sx = sum(xs); sy = sum(ys)
+    sxx = sum(x * x for x in xs)
+    sxy = sum(x * y for x, y in zip(xs, ys))
+    denom = n * sxx - sx * sx
+    if abs(denom) < 0.001: return 8.0
+    return (n * sxy - sx * sy) / denom
+
+
+def _median(xs: list[float]) -> float:
+    """Median of a small list. Pure Python."""
+    s = sorted(xs)
+    n = len(s)
+    if n % 2:
+        return s[n // 2]
+    return (s[n // 2 - 1] + s[n // 2]) / 2.0
+
+
+# ---------------------------------------------------------------------------
+# Pure-MLX fallbacks
+# ---------------------------------------------------------------------------
+
+def _expected_accepted_markov(
+    alpha: mx.array, rho: float, ns: mx.array,
+) -> mx.array:
+    """Markov expected acceptance — pure MLX reference."""
+    lam = alpha - rho
+    d = 1.0 - lam + 1e-10
+    lam_pow_n = lam ** ns
+    return ns * rho / d + lam * (1.0 - alpha) * (1.0 - lam_pow_n) / (d * d)
+
+
+# ---------------------------------------------------------------------------
+# Public convenience API
+# ---------------------------------------------------------------------------
+
+def bod_optimal_bet(
+    mode: str = 'chain',
+    alpha: float = 0.85,
+    c_scale: float = 8.0,
+    c_fixed: float = 47.0,
+    rho: float = 0.0,
+    log_slope: float = 0.71,
+    log_offset: float = 5.18,
+    min_bet: int = 2,
+    max_bet: int = 16,
+) -> int:
+    """Stateless convenience — pick optimal bet given known parameters.
+
+    Chain mode:
+    >>> bod_optimal_bet('chain', alpha=0.85, c_scale=8.0, c_fixed=47.0)
+    7
+    >>> bod_optimal_bet('chain', alpha=0.95, c_scale=8.0, c_fixed=47.0)
+    13
+
+    Tree mode:
+    >>> bod_optimal_bet('tree', c_scale=0.05, c_fixed=100.0,
+    ...                 log_slope=0.71, log_offset=5.18,
+    ...                 min_bet=16, max_bet=1024)
+    512
+    """
+    if mode == 'chain':
+        if rho < 1e-8:
+            return _analytical_gamma(alpha, c_scale, c_fixed, min_bet, max_bet)
+        return _chain_sweep_metal(
+            alpha, rho, c_scale, c_fixed, min_bet, max_bet,
+        )
+    else:
+        return _analytical_budget(
+            log_slope, log_offset, c_scale, c_fixed, min_bet, max_bet,
+        )

--- a/dflash_mlx/chat_cli.py
+++ b/dflash_mlx/chat_cli.py
@@ -30,10 +30,13 @@ def parse_args() -> argparse.Namespace:
             "parallel-replay",
             "parallel-lazy-logits",
             "parallel-greedy-argmax",
+            "ddtree",
         ],
         default="parallel-replay",
     )
     parser.add_argument("--verify-chunk-size", type=int, default=4)
+    parser.add_argument("--ddtree-budget", type=int, default=64)
+    parser.add_argument("--ddtree-use-bod", action="store_true")
     parser.add_argument("--max-turns", type=int, default=6)
     parser.add_argument("--show-stats", action="store_true")
     return parser.parse_args()
@@ -93,6 +96,8 @@ def main() -> None:
             verify_mode=args.verify_mode,
             verify_chunk_size=args.verify_chunk_size,
             skip_special_tokens=True,
+            ddtree_budget=args.ddtree_budget,
+            ddtree_use_bod=args.ddtree_use_bod,
         )
         answer = result.text.strip()
         print(f"assistant> {answer}\n")

--- a/dflash_mlx/cli.py
+++ b/dflash_mlx/cli.py
@@ -86,15 +86,42 @@ def parse_args() -> argparse.Namespace:
             "parallel-replay",
             "parallel-lazy-logits",
             "parallel-greedy-argmax",
+            "ddtree",
         ],
         default="parallel-replay",
         help=(
             "Verifier strategy. All options are exact. 'parallel-greedy-argmax' "
-            "only supports temperature=0. 'parallel-lazy-logits' keeps exact "
-            "prefix checks but computes verifier logits in chunks."
+            "only supports temperature=0. 'ddtree' enables Diffusion Draft Tree "
+            "(DDTree) verification with a configurable node budget."
         ),
     )
     parser.add_argument("--verify-chunk-size", type=int, default=4)
+    parser.add_argument(
+        "--ddtree-budget",
+        type=int,
+        default=64,
+        help=(
+            "DDTree node budget B. Controls how many candidate tokens the "
+            "tree verifier evaluates per round. Only used with --verify-mode ddtree."
+        ),
+    )
+    parser.add_argument(
+        "--ddtree-use-bod",
+        action="store_true",
+        help=(
+            "Enable Bet-Optimal Drafting (BOD) in tree mode to dynamically "
+            "select the DDTree node budget. Only used with --verify-mode ddtree."
+        ),
+    )
+    parser.add_argument(
+        "--use-bod",
+        action="store_true",
+        help=(
+            "Enable Bet-Optimal Drafting (BOD) in chain mode to dynamically "
+            "select the draft length gamma. Only used with vanilla DFlash "
+            "(not --verify-mode ddtree)."
+        ),
+    )
     parser.add_argument("--draft-quant-bits", type=int, default=None)
     parser.add_argument("--draft-quant-group-size", type=int, default=64)
     parser.add_argument(
@@ -221,6 +248,9 @@ def main() -> None:
             verify_mode=args.verify_mode,
             verify_chunk_size=args.verify_chunk_size,
             reset_peak_memory=False,
+            ddtree_budget=args.ddtree_budget,
+            ddtree_use_bod=args.ddtree_use_bod,
+            use_bod=args.use_bod,
         )
         log(
             f"[warmup {warmup_idx + 1}/{args.warmup_runs}] "
@@ -236,6 +266,9 @@ def main() -> None:
         verify_mode=args.verify_mode,
         verify_chunk_size=args.verify_chunk_size,
         profile=args.profile,
+        ddtree_budget=args.ddtree_budget,
+        ddtree_use_bod=args.ddtree_use_bod,
+        use_bod=args.use_bod,
     )
     metrics = result.metrics
 
@@ -254,6 +287,16 @@ def main() -> None:
     log(f"Verify mode:              {args.verify_mode}")
     if args.verify_mode in {"chunked", "parallel-lazy-logits"}:
         log(f"Verify chunk size:        {args.verify_chunk_size}")
+    if args.verify_mode == "ddtree":
+        log(f"DDTree budget:            {args.ddtree_budget}")
+        if args.ddtree_use_bod:
+            log(f"DDTree BOD:               enabled")
+            if "bod_final_budget" in metrics:
+                log(f"DDTree BOD final budget:  {metrics['bod_final_budget']}")
+    if args.use_bod and args.verify_mode != "ddtree":
+        log(f"BOD (chain mode):         enabled")
+        if "bod_final_gamma" in metrics:
+            log(f"BOD final gamma:          {metrics['bod_final_gamma']}")
     log(f"Prompt tokens:            {metrics['num_input_tokens']}")
     log(f"Generated tokens:         {metrics['num_output_tokens']}")
     log(f"Prefill time:             {metrics['prefill_time_s']:.2f}s")

--- a/dflash_mlx/ddtree.py
+++ b/dflash_mlx/ddtree.py
@@ -1,0 +1,532 @@
+"""Diffusion Draft Tree (DDTree) — tree-based speculative decoding on Apple Silicon.
+
+Implements the DDTree method from Ringel & Romano (2026):
+  "Accelerating Speculative Decoding with Block Diffusion Draft Trees"
+
+DDTree builds a draft tree from the per-position marginal distributions
+produced by a single DFlash block diffusion forward pass, selects the
+top-B prefixes via a best-first heap (Algorithm 1), verifies them in one
+target-model pass with tree attention, and walks the result.
+
+Integrates Bet-Optimal Drafting (BOD) in tree mode to dynamically select
+the node budget B that maximizes throughput.
+"""
+
+from __future__ import annotations
+
+import heapq
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import mlx.core as mx
+
+from .adapters import LoadedTargetModel
+from .bet_optimal_drafting import BODConfig, BODController
+from .draft import DFlashDraftModel
+from .runtime import sample_tokens, stop_position, trim_draft_cache
+
+
+# ---------------------------------------------------------------------------
+# Tree data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _TreeNode:
+    token_id: int
+    depth: int
+    parent_idx: int
+    log_prob: float
+    rank_tuple: tuple[int, ...]
+    children: list[int] = field(default_factory=list)
+
+
+@dataclass
+class DraftTree:
+    """Draft tree built from block diffusion per-position marginals."""
+
+    nodes: list[_TreeNode] = field(default_factory=list)
+    root_token: int = -1
+    block_size: int = 0
+
+    @property
+    def size(self) -> int:
+        return len(self.nodes)
+
+
+# ---------------------------------------------------------------------------
+# Algorithm 1: Best-first draft-tree construction
+# ---------------------------------------------------------------------------
+
+def build_draft_tree(
+    draft_logits: mx.array,
+    bonus_token: int,
+    budget: int,
+    block_size: int,
+) -> DraftTree:
+    """Build an optimal draft tree from one DFlash forward pass.
+
+    Implements Algorithm 1 from the DDTree paper. Given per-position
+    logits, selects the B highest-probability prefixes under the
+    factorized distribution Q using a max-heap.
+
+    The heap stores rank tuples rho = (rho_1, ..., rho_d) scored by their
+    log-probability sigma(rho) = sum log q^(rho_i)_i. When a tuple rho
+    is popped, two new candidates may be pushed:
+      - next sibling: (rho_1, ..., rho_{d-1}, rho_d + 1)  (if rho_d + 1 < K)
+      - first child:  (rho_1, ..., rho_d, 0)               (if d < L)
+    """
+    L = min(block_size, draft_logits.shape[1])
+    K = min(budget, draft_logits.shape[-1])
+
+    log_probs_all = mx.log(mx.softmax(draft_logits[0, :L, :], axis=-1))
+
+    top_k_tokens: list[list[int]] = []
+    top_k_log_probs: list[list[float]] = []
+    for i in range(L):
+        row = log_probs_all[i]
+        indices = mx.argsort(row)[::-1][:K]
+        indices_list = indices.tolist()
+        top_k_tokens.append(indices_list)
+        top_k_log_probs.append([float(row[idx]) for idx in indices_list])
+
+    tree = DraftTree(root_token=bonus_token, block_size=L)
+    rank_to_idx: dict[tuple[int, ...], int] = {}
+
+    max_heap: list[tuple[float, int, tuple[int, ...]]] = []
+    counter = 0
+
+    first_rho = (0,)
+    first_lp = top_k_log_probs[0][0]
+    heapq.heappush(max_heap, (-first_lp, counter, first_rho))
+    counter += 1
+
+    while len(tree.nodes) < budget and max_heap:
+        neg_lp, _, rho = heapq.heappop(max_heap)
+        d = len(rho)
+
+        parent_idx = -1
+        if d > 1:
+            parent_rho = rho[:-1]
+            parent_idx = rank_to_idx.get(parent_rho, -1)
+
+        tid = top_k_tokens[d - 1][rho[-1]]
+        lp = -neg_lp
+
+        node_idx = len(tree.nodes)
+        node = _TreeNode(
+            token_id=tid,
+            depth=d,
+            parent_idx=parent_idx,
+            log_prob=lp,
+            rank_tuple=rho,
+        )
+        tree.nodes.append(node)
+        rank_to_idx[rho] = node_idx
+
+        if parent_idx >= 0:
+            tree.nodes[parent_idx].children.append(node_idx)
+
+        if rho[-1] + 1 < K:
+            sib_rho = rho[:-1] + (rho[-1] + 1,)
+            sib_lp = lp - top_k_log_probs[d - 1][rho[-1]] + top_k_log_probs[d - 1][rho[-1] + 1]
+            heapq.heappush(max_heap, (-sib_lp, counter, sib_rho))
+            counter += 1
+
+        if d < L:
+            child_rho = rho + (0,)
+            child_lp = lp + top_k_log_probs[d][0]
+            heapq.heappush(max_heap, (-child_lp, counter, child_rho))
+            counter += 1
+
+    return tree
+
+
+# ---------------------------------------------------------------------------
+# Tree flattening for target-model verification
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TreeTensors:
+    token_ids: mx.array
+    position_ids: mx.array
+    attention_mask: mx.array
+    tree_size: int
+    tree: DraftTree
+    flat_order: list[int]
+
+
+def compile_tree_tensors(
+    tree: DraftTree,
+    context_len: int,
+) -> TreeTensors:
+    """Flatten the draft tree into tensors for one target-model forward pass.
+
+    Tokens are laid out in BFS order starting with the bonus token (root).
+    Position ids equal tree depth. The attention mask ensures each drafted
+    node attends to all context tokens plus only its ancestors (and itself)
+    within the tree -- ancestor-only tree attention (Section 4.4).
+
+    NOTE: The current adapter API applies causal attention by default.
+    The ancestor-only mask is computed here for correctness and for
+    future use when adapters support custom masks. With causal attention,
+    each node sees all predecessors (not just ancestors), which makes
+    verification approximate but still functional.
+    """
+    B = tree.size
+    if B == 0:
+        return TreeTensors(
+            token_ids=mx.array([], dtype=mx.uint32),
+            position_ids=mx.array([], dtype=mx.int32),
+            attention_mask=mx.zeros((0, 0), dtype=mx.float32),
+            tree_size=0,
+            tree=tree,
+            flat_order=[],
+        )
+
+    flat_order = _bfs_order(tree)
+    order_inv = {orig: flat for flat, orig in enumerate(flat_order)}
+
+    ancestor_sets: list[set[int]] = []
+    for orig_idx in flat_order:
+        anc: set[int] = set()
+        cur = orig_idx
+        while cur >= 0:
+            anc.add(cur)
+            cur = tree.nodes[cur].parent_idx
+        ancestor_sets.append(anc)
+
+    total_len = 1 + B
+    mask_np = [[0.0] * total_len for _ in range(B)]
+
+    for flat_i in range(B):
+        mask_np[flat_i][0] = 1.0
+        for anc_orig in ancestor_sets[flat_i]:
+            flat_j = order_inv[anc_orig]
+            mask_np[flat_i][1 + flat_j] = 1.0
+
+    token_ids_list = [tree.nodes[idx].token_id for idx in flat_order]
+    position_ids_list = [tree.nodes[idx].depth for idx in flat_order]
+
+    return TreeTensors(
+        token_ids=mx.array(token_ids_list, dtype=mx.uint32),
+        position_ids=mx.array(position_ids_list, dtype=mx.int32),
+        attention_mask=mx.array(mask_np, dtype=mx.float32),
+        tree_size=B,
+        tree=tree,
+        flat_order=flat_order,
+    )
+
+
+def _bfs_order(tree: DraftTree) -> list[int]:
+    order: list[int] = []
+    queue: list[int] = []
+    for i, node in enumerate(tree.nodes):
+        if node.depth == 1:
+            queue.append(i)
+    queue.sort(key=lambda i: tree.nodes[i].rank_tuple)
+    while queue:
+        next_queue: list[int] = []
+        for idx in queue:
+            order.append(idx)
+            next_queue.extend(tree.nodes[idx].children)
+        next_queue.sort(key=lambda i: tree.nodes[i].rank_tuple)
+        queue = next_queue
+    return order
+
+
+# ---------------------------------------------------------------------------
+# Verifier walk
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WalkResult:
+    accepted_tokens: list[int]
+    accepted_count: int
+    bonus_token: int
+
+
+def walk_tree(
+    tree: DraftTree,
+    flat_order: list[int],
+    verifier_logits: mx.array,
+    temperature: float,
+) -> WalkResult:
+    """Walk the draft tree following the target model's decoding rule.
+
+    verifier_logits has shape [1, 1+B, V] where position 0 is the bonus
+    token and positions 1..B are the tree nodes in flat_order. At each
+    step the target model's logits at the current position determine
+    the next token. If that token matches a child in the tree, the walk
+    continues; otherwise it stops and the unmatched token becomes the
+    new bonus token.
+
+    Figure 2(b): starting from the bonus token b, check whether the
+    token selected by the target model matches a child. If yes, accept
+    and continue. If no, stop; the first unmatched target token becomes
+    the next bonus token.
+    """
+    order_inv = {orig: flat for flat, orig in enumerate(flat_order)}
+
+    node_children: dict[int, dict[int, int]] = {}
+    for i, node in enumerate(tree.nodes):
+        node_children[i] = {}
+        for child_idx in node.children:
+            node_children[i][tree.nodes[child_idx].token_id] = child_idx
+
+    root_children: dict[int, int] = {}
+    for i, node in enumerate(tree.nodes):
+        if node.depth == 1:
+            root_children[node.token_id] = i
+
+    accepted_tokens: list[int] = []
+    current_node = -1
+
+    while True:
+        if current_node == -1:
+            child_dict = root_children
+        else:
+            child_dict = node_children.get(current_node, {})
+
+        if current_node == -1:
+            logits_pos = 0
+        else:
+            logits_pos = 1 + order_inv.get(current_node, 0)
+
+        logits_at = verifier_logits[0, logits_pos, :]
+        selected = int(sample_tokens(logits_at[None, None, :], temperature).item())
+
+        if selected in child_dict:
+            next_node = child_dict[selected]
+            accepted_tokens.append(selected)
+            current_node = next_node
+        else:
+            return WalkResult(
+                accepted_tokens=accepted_tokens,
+                accepted_count=len(accepted_tokens),
+                bonus_token=selected,
+            )
+
+
+# ---------------------------------------------------------------------------
+# DDTree generate loop
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DDTreeConfig:
+    budget: int = 64
+    use_bod: bool = False
+    bod_config: BODConfig | None = None
+    profile: bool = False
+
+
+def ddtree_generate(
+    target: LoadedTargetModel,
+    draft: DFlashDraftModel,
+    prompt_tokens: mx.array,
+    max_new_tokens: int,
+    temperature: float,
+    stop_token_ids: set[int],
+    layer_ids: list[int],
+    config: DDTreeConfig | None = None,
+) -> tuple[list[int], dict[str, Any]]:
+    """DDTree speculative decoding with tree-based verification.
+
+    Per round:
+    1. Run one DFlash drafter pass -> per-position marginals {q_i}.
+    2. Build draft tree with B nodes (Algorithm 1).
+    3. Flatten tree + bonus token into one sequence, run target model.
+    4. Walk tree; accept matched path; fix caches; carry next bonus.
+
+    Cache management:
+    The accepted path through the tree is a specific trajectory (not a
+    prefix of the BFS-ordered input), so we cannot simply trim the tail.
+    Instead we:
+      a. Snapshot SSM caches (Qwen3.5) before the tree forward pass.
+      b. Forward the tree input through the target model.
+      c. Walk the tree to determine the accepted path.
+      d. Rewind KV caches by the full tree token count.
+      e. Restore SSM caches from the snapshot.
+      f. Replay the accepted path [bonus, accepted_1, ..., accepted_d]
+         through the target model to rebuild both KV and SSM caches
+         correctly, and extract target_hidden for the next draft step.
+
+    The replay adds a short forward pass of (1 + accepted_count) tokens,
+    which is a small fraction of the tree verification cost.
+    """
+    if config is None:
+        config = DDTreeConfig()
+
+    budget = config.budget
+    block_size = draft.block_size
+
+    bod: BODController | None = None
+    if config.use_bod:
+        bod_cfg = config.bod_config or BODConfig(
+            mode="tree",
+            min_bet=16,
+            max_bet=1024,
+        )
+        bod = BODController(bod_cfg)
+
+    target_cache = target.make_cache()
+    draft_cache = draft.make_cache()
+    total_max_tokens = int(prompt_tokens.shape[0]) + max_new_tokens
+    prompt_len = int(prompt_tokens.shape[0])
+
+    has_ssm = target.adapter.family in ("qwen3_5",)
+
+    t0 = time.perf_counter()
+    logits, target_hidden = target.forward_with_hidden_states(
+        prompt_tokens[None],
+        target_cache,
+        layer_ids,
+    )
+    first_token = int(sample_tokens(logits[:, -1, :], temperature).item())
+    mx.eval(logits, target_hidden)
+    prefill_time = time.perf_counter() - t0
+
+    output_tokens = prompt_tokens.tolist() + [first_token]
+    pos = prompt_len
+    acceptance_lengths: list[int] = []
+
+    decode_start = time.perf_counter()
+    while pos < total_max_tokens:
+        if bod is not None:
+            budget = bod.optimal_bet()
+
+        effective_budget = max(1, min(budget, 1024))
+
+        draft_t0 = time.perf_counter()
+        bonus_token = output_tokens[pos]
+        block_tokens = [bonus_token] + [draft.mask_token_id] * (block_size - 1)
+        block_input = mx.array(block_tokens, dtype=mx.uint32)[None]
+        noise_embedding = target.embed_tokens(block_input)
+
+        draft_hidden = draft(
+            noise_embedding=noise_embedding,
+            target_hidden=target_hidden,
+            cache=draft_cache,
+        )
+        draft_logits = target.lm_head_logits(draft_hidden[:, 1:, :])
+        mx.eval(draft_logits)
+        trim_draft_cache(draft_cache, block_size)
+        draft_time = time.perf_counter() - draft_t0
+
+        tree_t0 = time.perf_counter()
+        tree = build_draft_tree(
+            draft_logits=draft_logits[:, :block_size, :],
+            bonus_token=bonus_token,
+            budget=effective_budget,
+            block_size=block_size,
+        )
+        tree_time = time.perf_counter() - tree_t0
+
+        if tree.size == 0:
+            out_tok = int(sample_tokens(draft_logits[0, 0:1, :], temperature).item())
+            output_tokens.append(out_tok)
+            pos += 1
+            acceptance_lengths.append(0)
+            continue
+
+        tree_tensors = compile_tree_tensors(tree, pos)
+        total_tree_tokens = 1 + tree.size
+
+        if has_ssm:
+            ssm_snapshot = target.snapshot_linear_caches(target_cache)
+
+        verify_t0 = time.perf_counter()
+        tree_input_ids = mx.array(
+            [bonus_token] + [tree.nodes[i].token_id for i in tree_tensors.flat_order],
+            dtype=mx.uint32,
+        )[None]
+
+        verifier_logits, _, _ = target.forward_with_hidden_states(
+            tree_input_ids,
+            target_cache,
+            layer_ids,
+            return_rollback_records=True,
+        )
+        mx.eval(verifier_logits)
+        verify_time = time.perf_counter() - verify_t0
+
+        walk_result = walk_tree(
+            tree=tree,
+            flat_order=tree_tensors.flat_order,
+            verifier_logits=verifier_logits,
+            temperature=temperature,
+        )
+
+        accepted_count = walk_result.accepted_count
+        new_bonus = walk_result.bonus_token
+        acceptance_lengths.append(accepted_count)
+
+        target.rewind_kv_caches(target_cache, total_tree_tokens)
+
+        if has_ssm:
+            target.restore_linear_caches(target_cache, ssm_snapshot)
+
+        if accepted_count > 0:
+            replay_ids = mx.array(
+                [bonus_token] + walk_result.accepted_tokens,
+                dtype=mx.uint32,
+            )[None]
+        else:
+            replay_ids = mx.array([[bonus_token]], dtype=mx.uint32)
+
+        replay_logits, target_hidden = target.forward_with_hidden_states(
+            replay_ids,
+            target_cache,
+            layer_ids,
+        )
+        mx.eval(replay_logits, target_hidden)
+
+        if accepted_count == 0:
+            target.rewind_kv_caches(target_cache, 1)
+
+        output_tokens = output_tokens[:pos + 1]
+        output_tokens.extend(walk_result.accepted_tokens)
+        output_tokens.append(new_bonus)
+        pos += 1 + accepted_count
+
+        if bod is not None:
+            bod.observe(
+                bet=effective_budget,
+                accepted=accepted_count,
+                cycle_time_ms=(draft_time + verify_time + tree_time) * 1000,
+                draft_time_ms=draft_time * 1000,
+                verify_time_ms=verify_time * 1000,
+                confidence=float(mx.max(mx.softmax(draft_logits[0, 0, :])).item()),
+            )
+
+        if stop_position(output_tokens, prompt_len, stop_token_ids) is not None:
+            break
+        if len(output_tokens) > total_max_tokens:
+            break
+
+    decode_time = time.perf_counter() - decode_start
+    output_tokens = output_tokens[:total_max_tokens]
+    generated_tokens = max(len(output_tokens) - prompt_len, 0)
+    total_time = prefill_time + decode_time
+
+    metrics: dict[str, Any] = {
+        "num_input_tokens": prompt_len,
+        "num_output_tokens": generated_tokens,
+        "prefill_time_s": prefill_time,
+        "decode_time_s": decode_time,
+        "total_time_s": total_time,
+        "prompt_tps": prompt_len / max(prefill_time, 1e-9),
+        "generation_tps": generated_tokens / max(decode_time, 1e-9),
+        "end_to_end_tps": generated_tokens / max(total_time, 1e-9),
+        "avg_acceptance_length": sum(acceptance_lengths) / max(len(acceptance_lengths), 1),
+        "acceptance_lengths": acceptance_lengths,
+        "peak_memory_gb": mx.get_peak_memory() / 1e9,
+        "target_cache_summary": target.cache_summary(target_cache),
+        "speculative_tokens": block_size,
+        "ddtree_budget": budget,
+        "ddtree_use_bod": config.use_bod,
+    }
+    if bod is not None:
+        metrics["bod_final_budget"] = budget
+
+    return output_tokens, metrics

--- a/dflash_mlx/runtime.py
+++ b/dflash_mlx/runtime.py
@@ -6,6 +6,7 @@ from typing import Any
 import mlx.core as mx
 
 from .adapters import LoadedTargetModel
+from .bet_optimal_drafting import BODConfig, BODController
 from .draft import DFlashDraftModel
 
 
@@ -359,6 +360,8 @@ def dflash_generate(
     verify_mode: str,
     verify_chunk_size: int,
     profile: bool = False,
+    use_bod: bool = False,
+    bod_config: BODConfig | None = None,
 ) -> tuple[list[int], dict[str, Any]]:
     target_cache = target.make_cache()
     draft_cache = draft.make_cache()
@@ -369,6 +372,11 @@ def dflash_generate(
         block_size = draft.block_size
     else:
         block_size = max(1, min(speculative_tokens, draft.block_size))
+
+    bod: BODController | None = None
+    if use_bod:
+        bod_cfg = bod_config or BODConfig(mode="chain", min_bet=2, max_bet=block_size)
+        bod = BODController(bod_cfg)
 
     sync_start = time.perf_counter()
     logits, target_hidden = target.forward_with_hidden_states(
@@ -386,6 +394,10 @@ def dflash_generate(
 
     decode_start = time.perf_counter()
     while start < total_max_tokens:
+        if bod is not None:
+            block_size = bod.optimal_bet()
+            block_size = max(2, min(block_size, draft.block_size))
+
         draft_start = profile_start(profile_times)
         block_tokens = [output_tokens[start]] + [draft.mask_token_id] * (block_size - 1)
         block_input = mx.array(block_tokens, dtype=mx.uint32)[None]
@@ -404,6 +416,7 @@ def dflash_generate(
         block_tokens[1:] = drafted_suffix[: block_size - 1]
         add_profile_elapsed(profile_times, "draft_time_s", draft_start)
 
+        verify_wall_start = time.perf_counter()
         verify_start = profile_start(profile_times)
         if verify_mode == "stream":
             accepted_inputs, posterior_token, verifier_hidden = verify_block_stream(
@@ -472,6 +485,20 @@ def dflash_generate(
         output_tokens.extend(block_tokens[:accepted_inputs])
         output_tokens.append(posterior_token)
         start += accepted_inputs
+
+        if bod is not None:
+            draft_wall_ms = (verify_wall_start - draft_start) * 1000
+            verify_wall_ms = (time.perf_counter() - verify_wall_start) * 1000
+            cycle_time_ms = draft_wall_ms + verify_wall_ms
+            bod.observe(
+                bet=block_size,
+                accepted=accepted_inputs,
+                cycle_time_ms=cycle_time_ms,
+                draft_time_ms=draft_wall_ms,
+                verify_time_ms=verify_wall_ms,
+                confidence=float(mx.max(mx.softmax(draft_logits[:, 0, :])).item()),
+            )
+
         add_profile_elapsed(
             profile_times,
             "bookkeeping_time_s",
@@ -506,7 +533,10 @@ def dflash_generate(
         "peak_memory_gb": peak_memory_gb(),
         "target_cache_summary": target.cache_summary(target_cache),
         "speculative_tokens": block_size,
+        "use_bod": use_bod,
     }
+    if bod is not None:
+        metrics["bod_final_gamma"] = block_size
     if profile_times is not None:
         profiled_time = sum(
             profile_times.get(key, 0.0)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -12,16 +12,21 @@ def test_public_api_importable():
     import dflash_mlx
 
     expected = {
+        "DDTreeConfig",
         "DFlashGenerator",
         "DFlashResult",
         "DFlashDraftModel",
+        "DraftTree",
         "LoadedTargetModel",
         "adapter_for_model_type",
+        "build_draft_tree",
         "dflash_generate",
+        "ddtree_generate",
         "load_draft_model",
         "load_target_model",
         "longest_prefix_match",
         "sample_tokens",
+        "walk_tree",
     }
     assert expected.issubset(set(dflash_mlx.__all__))
     for name in expected:


### PR DESCRIPTION
## The Casino

Imagine you're at a casino table. The **draft model** is the gambler. The **target model** is the house. Every round of speculative decoding works like this:

1. The **gambler** places a bet — they predict what the house will say next.
2. The **house** checks the gambler's prediction. Every correct guess is a win (tokens accepted). The first wrong guess ends the round.

The faster we cycle through rounds, the more tokens we produce per second. But there's a tension:

- **Bet too small** → you win a little each round, but you pay a fixed "table fee" (the house verification) every single time. The fee eats your profits.
- **Bet too big** → you avoid the table fee, but the bet itself costs more (more draft tokens to generate, or a bigger tree to verify). And the longer the bet, the more likely one token is wrong and the whole tail is rejected.

The sweet spot depends on the odds and the costs, and it changes in real time.

## What we built

### Bet-Optimal Drafting (`bet_optimal_drafting.py`)

**BOD is the pit boss that tells the gambler exactly how much to bet.**

It models throughput as a simple ratio:

```
throughput = (expected tokens won) / (time cost of the round)
```

And finds the bet size that maximizes it. It works in two modes:

| Mode | What it optimizes | Fixed cost | Scaling cost |
|---|---|---|---|
| **Chain** (vanilla DFlash) | How many tokens to draft in a line (γ) | House verification | Each extra draft token |
| **Tree** (DDTree) | How many nodes in the draft tree (B) | The draft pass | Each extra tree node to verify |

The math is the same — just the costs swap. Each mode has three tiers of optimization:

1. **Dominance check**: If the fixed cost dwarfs the variable cost, bet the max. One comparison, zero math.
2. **Lambert W closed-form**: A 250-year-old formula solves the optimization exactly. One logarithm, one Lambert W, no GPU needed.
3. **Metal kernel sweep**: When the formula doesn't apply, we dispatch one GPU thread per candidate and pick the best. One GPU dispatch, done.

BOD learns from every round — it watches how long drafting and verifying actually take, tracks acceptance rates, and continuously adjusts the bet size.

### DDTree (`ddtree.py`)

**DDTree is the gambler playing multiple hands at once.**

In vanilla DFlash, the gambler lays down one line of tokens. If the house rejects at position 3, tokens 4–16 are wasted — even though some of them might have been right under a different path.

DDTree fixes this. Instead of one line, the gambler builds a **tree** of the most promising continuations from a single draft pass. The tree is built using a max-heap (Algorithm 1 from the [DDTree paper](https://arxiv.org/abs/2602.06036)) that always expands the highest-probability path first. The house then checks all branches in a **single pass** using tree attention (each node only looks at its ancestors).

**Example**: With a budget of 64 nodes, DDTree might build a tree that's 4–5 tokens deep across the top candidates. The house verifies all 64 candidates at once. If the house's choice at step 1 leads to a dead end, it just picks another branch — no wasted round.

The key algorithmic result (Proposition 2 from the paper): the optimal tree under our surrogate objective is simply the B highest-probability prefixes, and they automatically form a valid tree. The best-first heap finds them in O(B log B) time.

### How they work together

```
┌──────────────────────────────────────────────────┐
│  Every decode round:                              │
│                                                   │
│  1. BOD picks the optimal bet size                │
│     • Chain mode: how many tokens to draft (γ)    │
│     • Tree mode: how many tree nodes (B)          │
│                                                   │
│  2. Gambler places the bet                        │
│     • Chain: draft γ tokens in a line             │
│     • Tree: build a tree with B nodes             │
│                                                   │
│  3. House verifies in one pass                    │
│     • Chain: check the line                       │
│     • Tree: walk the tree, accept the best path   │
│                                                   │
│  4. BOD observes the outcome                      │
│     • How many tokens accepted?                   │
│     • How long did draft/verify take?             │
│     → Adjusts the bet for next round              │
└──────────────────────────────────────────────────┘
```

## CLI usage

```bash
# Vanilla DFlash (chain mode)
uv run dflash-mlx --warmup-runs 1 --max-new-tokens 128

# Vanilla DFlash + BOD (auto-tunes draft length)
uv run dflash-mlx --use-bod --warmup-runs 1 --max-new-tokens 128

# DDTree with fixed budget
uv run dflash-mlx --verify-mode ddtree --ddtree-budget 64 --warmup-runs 1

# DDTree + BOD (auto-tunes tree budget)
uv run dflash-mlx --verify-mode ddtree --ddtree-budget 64 --ddtree-use-bod
```

## What's new

| File | What it does |
|---|---|
| `dflash_mlx/bet_optimal_drafting.py` | BOD controller — Lambert W solver, Metal kernels, online cost/acceptance tracking |
| `dflash_mlx/ddtree.py` | DDTree — Algorithm 1 tree builder, ancestor-only attention mask, tree verification walk |
| `dflash_mlx/runtime.py` | BOD integration in chain mode (vanilla DFlash) |
| `dflash_mlx/api.py` | `verify_mode="ddtree"`, `use_bod`, `ddtree_budget`, `ddtree_use_bod` params |
| `dflash_mlx/cli.py` | `--verify-mode ddtree`, `--ddtree-budget`, `--ddtree-use-bod`, `--use-bod` flags |
| `dflash_mlx/chat_cli.py` | Same flags for interactive chat |

## Performance note

DDTree currently uses a replay-based KV cache strategy: after tree verification, we rewind and replay the accepted path to rebuild the cache. This adds one short forward pass per round. On large models (27B+), this replay cost can outweigh the tree benefit. A future optimization will avoid replay by doing selective KV cache retention instead.