### PR TITLE
feat: add streaming generation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,18 @@ from dflash_mlx import DFlashGenerator
 runner = DFlashGenerator()
 result = runner.generate("Write a quicksort in Python.", max_new_tokens=128)
 print(result.text)
+
+for event in runner.stream("Write a quicksort in Python.", max_new_tokens=128):
+    if not event.finished:
+        print(event.delta, end="", flush=True)
 ```
+
+Use `uv run dflash-mlx --stream` or `uv run dflash-mlx-chat --stream` to print
+verified text as it is committed.
 
 ## OpenAI-compatible local server
 
-A minimal text-only, non-streaming OpenAI-compatible HTTP server is included for local integrations:
+A minimal text-only OpenAI-compatible HTTP server is included for local integrations:
 
 ```bash
 dflash-mlx-openai-server \
@@ -47,7 +54,9 @@ Endpoints:
 Current limitations:
 - text-only message content
 - no image input
-- no streaming responses yet
+
+`POST /v1/chat/completions` supports both full responses and streaming SSE chunks
+with `"stream": true`.
 
 ## Supported models
 

--- a/dflash_mlx/__init__.py
+++ b/dflash_mlx/__init__.py
@@ -1,18 +1,20 @@
 """MLX runtime for DFlash speculative decoding on Apple Silicon."""
 
 from .adapters import LoadedTargetModel, adapter_for_model_type, load_target_model
-from .api import DFlashGenerator, DFlashResult
+from .api import DFlashGenerator, DFlashResult, DFlashStreamEvent
 from .draft import DFlashDraftModel, load_draft_model
-from .runtime import dflash_generate, longest_prefix_match, sample_tokens
+from .runtime import dflash_generate, dflash_generate_stream, longest_prefix_match, sample_tokens
 from . import openai_server
 
 __all__ = [
     "DFlashGenerator",
     "DFlashResult",
+    "DFlashStreamEvent",
     "DFlashDraftModel",
     "LoadedTargetModel",
     "adapter_for_model_type",
     "dflash_generate",
+    "dflash_generate_stream",
     "load_draft_model",
     "load_target_model",
     "longest_prefix_match",

--- a/dflash_mlx/api.py
+++ b/dflash_mlx/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -9,7 +10,7 @@ from mlx_lm.generate import wired_limit
 
 from .adapters import LoadedTargetModel, load_target_model
 from .draft import DFlashDraftModel, load_draft_model, maybe_quantize_draft_model
-from .runtime import dflash_generate
+from .runtime import dflash_generate, dflash_generate_stream
 
 
 DEFAULT_TARGET_MODEL = "mlx-community/Qwen3-4B-bf16"
@@ -22,6 +23,17 @@ class DFlashResult:
     output_tokens: list[int]
     generated_tokens: list[int]
     metrics: dict[str, Any]
+
+
+@dataclass
+class DFlashStreamEvent:
+    delta: str
+    text: str
+    token_ids: list[int]
+    output_tokens: list[int]
+    generated_tokens: list[int]
+    metrics: dict[str, Any] | None = None
+    finished: bool = False
 
 
 class DFlashGenerator:
@@ -101,6 +113,56 @@ class DFlashGenerator:
             metrics=metrics,
         )
 
+    def stream_from_tokens(
+        self,
+        prompt_tokens: mx.array,
+        max_new_tokens: int = 256,
+        temperature: float = 0.0,
+        speculative_tokens: int | None = None,
+        verify_mode: str = "parallel-replay",
+        verify_chunk_size: int = 4,
+        reset_peak_memory: bool = True,
+        skip_special_tokens: bool = False,
+        profile: bool = False,
+    ) -> Iterator[DFlashStreamEvent]:
+        prompt_len = int(prompt_tokens.shape[0])
+        decoded_text = ""
+        with wired_limit(self.target.model):
+            if reset_peak_memory:
+                mx.reset_peak_memory()
+            for event in dflash_generate_stream(
+                target=self.target,
+                draft=self.draft,
+                prompt_tokens=prompt_tokens,
+                max_new_tokens=max_new_tokens,
+                temperature=temperature,
+                stop_token_ids=self.target.stop_token_ids(),
+                layer_ids=self.draft.target_layer_ids,
+                speculative_tokens=speculative_tokens,
+                verify_mode=verify_mode,
+                verify_chunk_size=verify_chunk_size,
+                profile=profile,
+            ):
+                generated_tokens = event.output_tokens[prompt_len:]
+                text = self.target.tokenizer.decode(
+                    generated_tokens,
+                    skip_special_tokens=skip_special_tokens,
+                )
+                if text.startswith(decoded_text):
+                    delta = text[len(decoded_text) :]
+                else:
+                    delta = text
+                decoded_text = text
+                yield DFlashStreamEvent(
+                    delta=delta,
+                    text=text,
+                    token_ids=list(event.token_ids),
+                    output_tokens=list(event.output_tokens),
+                    generated_tokens=list(generated_tokens),
+                    metrics=event.metrics,
+                    finished=event.finished,
+                )
+
     def generate(
         self,
         prompt_text: str,
@@ -114,6 +176,30 @@ class DFlashGenerator:
         profile: bool = False,
     ) -> DFlashResult:
         return self.generate_from_tokens(
+            prompt_tokens=self.encode_prompt(prompt_text),
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            speculative_tokens=speculative_tokens,
+            verify_mode=verify_mode,
+            verify_chunk_size=verify_chunk_size,
+            reset_peak_memory=reset_peak_memory,
+            skip_special_tokens=skip_special_tokens,
+            profile=profile,
+        )
+
+    def stream(
+        self,
+        prompt_text: str,
+        max_new_tokens: int = 256,
+        temperature: float = 0.0,
+        speculative_tokens: int | None = None,
+        verify_mode: str = "parallel-replay",
+        verify_chunk_size: int = 4,
+        reset_peak_memory: bool = True,
+        skip_special_tokens: bool = False,
+        profile: bool = False,
+    ) -> Iterator[DFlashStreamEvent]:
+        return self.stream_from_tokens(
             prompt_tokens=self.encode_prompt(prompt_text),
             max_new_tokens=max_new_tokens,
             temperature=temperature,

--- a/dflash_mlx/chat_cli.py
+++ b/dflash_mlx/chat_cli.py
@@ -35,6 +35,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--verify-chunk-size", type=int, default=4)
     parser.add_argument("--max-turns", type=int, default=6)
+    parser.add_argument(
+        "--stream",
+        action="store_true",
+        help="Print assistant text as soon as verified tokens are committed.",
+    )
     parser.add_argument("--show-stats", action="store_true")
     return parser.parse_args()
 
@@ -85,19 +90,43 @@ def main() -> None:
             continue
 
         prompt = build_prompt(history, user_message, args.max_turns)
-        result = runner.generate(
-            prompt,
-            max_new_tokens=args.max_new_tokens,
-            temperature=args.temperature,
-            speculative_tokens=args.speculative_tokens,
-            verify_mode=args.verify_mode,
-            verify_chunk_size=args.verify_chunk_size,
-            skip_special_tokens=True,
-        )
-        answer = result.text.strip()
-        print(f"assistant> {answer}\n")
-        if args.show_stats:
+        if args.stream:
+            print("assistant> ", end="", flush=True)
+            final_event = None
+            for event in runner.stream(
+                prompt,
+                max_new_tokens=args.max_new_tokens,
+                temperature=args.temperature,
+                speculative_tokens=args.speculative_tokens,
+                verify_mode=args.verify_mode,
+                verify_chunk_size=args.verify_chunk_size,
+                skip_special_tokens=True,
+            ):
+                if event.finished:
+                    if event.delta:
+                        print(event.delta, end="", flush=True)
+                    final_event = event
+                elif event.delta:
+                    print(event.delta, end="", flush=True)
+            print("\n")
+            if final_event is None or final_event.metrics is None:
+                raise RuntimeError("Streaming generation did not produce a final event.")
+            answer = final_event.text.strip()
+            metrics = final_event.metrics
+        else:
+            result = runner.generate(
+                prompt,
+                max_new_tokens=args.max_new_tokens,
+                temperature=args.temperature,
+                speculative_tokens=args.speculative_tokens,
+                verify_mode=args.verify_mode,
+                verify_chunk_size=args.verify_chunk_size,
+                skip_special_tokens=True,
+            )
+            answer = result.text.strip()
             metrics = result.metrics
+            print(f"assistant> {answer}\n")
+        if args.show_stats:
             print(
                 "[stats] "
                 f"gen_tps={metrics['generation_tps']:.2f} "

--- a/dflash_mlx/cli.py
+++ b/dflash_mlx/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from huggingface_hub.utils import disable_progress_bars
 
-from .api import DEFAULT_DRAFT_MODEL, DEFAULT_TARGET_MODEL, DFlashGenerator
+from .api import DEFAULT_DRAFT_MODEL, DEFAULT_TARGET_MODEL, DFlashGenerator, DFlashResult
 from .history import (
     DEFAULT_HISTORY_PATH,
     append_rows,
@@ -113,6 +113,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--print-output", action="store_true")
     parser.add_argument(
+        "--stream",
+        action="store_true",
+        help="Print generated text as soon as verified tokens are committed.",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Print a single JSON result object and suppress progress logs.",
@@ -149,6 +154,8 @@ def main() -> None:
     args = parse_args()
     if args.prompt is not None and args.prompt_file is not None:
         raise SystemExit("Use either --prompt or --prompt-file, not both.")
+    if args.json and args.stream:
+        raise SystemExit("Use either --json or --stream, not both.")
     if args.json:
         disable_progress_bars()
     log = (lambda *items: None) if args.json else print
@@ -228,15 +235,42 @@ def main() -> None:
             f"accept={warm_result.metrics['avg_acceptance_length']:.2f}"
         )
 
-    result = runner.generate_from_tokens(
-        prompt_tokens=prompt_tokens,
-        max_new_tokens=args.max_new_tokens,
-        temperature=args.temperature,
-        speculative_tokens=args.speculative_tokens,
-        verify_mode=args.verify_mode,
-        verify_chunk_size=args.verify_chunk_size,
-        profile=args.profile,
-    )
+    if args.stream:
+        final_event = None
+        for event in runner.stream_from_tokens(
+            prompt_tokens=prompt_tokens,
+            max_new_tokens=args.max_new_tokens,
+            temperature=args.temperature,
+            speculative_tokens=args.speculative_tokens,
+            verify_mode=args.verify_mode,
+            verify_chunk_size=args.verify_chunk_size,
+            profile=args.profile,
+        ):
+            if event.finished:
+                if event.delta:
+                    print(event.delta, end="", flush=True)
+                final_event = event
+            elif event.delta:
+                print(event.delta, end="", flush=True)
+        print()
+        if final_event is None or final_event.metrics is None:
+            raise RuntimeError("Streaming generation did not produce a final event.")
+        result = DFlashResult(
+            text=final_event.text,
+            output_tokens=final_event.output_tokens,
+            generated_tokens=final_event.generated_tokens,
+            metrics=final_event.metrics,
+        )
+    else:
+        result = runner.generate_from_tokens(
+            prompt_tokens=prompt_tokens,
+            max_new_tokens=args.max_new_tokens,
+            temperature=args.temperature,
+            speculative_tokens=args.speculative_tokens,
+            verify_mode=args.verify_mode,
+            verify_chunk_size=args.verify_chunk_size,
+            profile=args.profile,
+        )
     metrics = result.metrics
 
     log("\n" + "=" * 60)
@@ -316,7 +350,7 @@ def main() -> None:
 
     if args.json:
         print(json.dumps(result_payload, indent=2, sort_keys=True))
-    elif args.print_output:
+    elif args.print_output and not args.stream:
         print(result.text)
 
 

--- a/dflash_mlx/openai_server.py
+++ b/dflash_mlx/openai_server.py
@@ -5,6 +5,7 @@ import json
 import sys
 import time
 import uuid
+from collections.abc import Iterator
 from dataclasses import dataclass
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -60,6 +61,33 @@ def build_chat_response(
     }
 
 
+def build_chat_stream_chunk(
+    *,
+    chunk_id: str,
+    created: int,
+    model: str,
+    delta: dict[str, str],
+    finish_reason: str | None = None,
+    usage: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": chunk_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": delta,
+                "finish_reason": finish_reason,
+            }
+        ],
+    }
+    if usage is not None:
+        payload["usage"] = usage
+    return payload
+
+
 def _extract_text_content(content: Any) -> str:
     if isinstance(content, str):
         return content
@@ -111,6 +139,16 @@ class GenerationResult:
     finish_reason: str = "stop"
 
 
+@dataclass
+class GenerationChunk:
+    delta: str
+    text: str
+    completion_tokens: int
+    prompt_tokens: int = 0
+    finish_reason: str | None = None
+    finished: bool = False
+
+
 class RunnerProtocol:
     def generate(
         self,
@@ -119,6 +157,15 @@ class RunnerProtocol:
         max_new_tokens: int,
         temperature: float,
     ) -> GenerationResult:
+        raise NotImplementedError
+
+    def stream(
+        self,
+        *,
+        prompt: str,
+        max_new_tokens: int,
+        temperature: float,
+    ) -> Iterator[GenerationChunk]:
         raise NotImplementedError
 
 
@@ -172,6 +219,49 @@ class DFlashRunner(RunnerProtocol):
             finish_reason=finish_reason,
         )
 
+    def stream(
+        self,
+        *,
+        prompt: str,
+        max_new_tokens: int,
+        temperature: float,
+    ) -> Iterator[GenerationChunk]:
+        for event in self.generator.stream(
+            prompt,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            speculative_tokens=self.speculative_tokens,
+            verify_mode=self.verify_mode,
+            verify_chunk_size=self.verify_chunk_size,
+            skip_special_tokens=True,
+        ):
+            if event.finished:
+                if event.delta:
+                    yield GenerationChunk(
+                        delta=event.delta,
+                        text=event.text,
+                        completion_tokens=len(event.generated_tokens),
+                    )
+                metrics = event.metrics or {}
+                prompt_tokens = int(metrics.get("num_input_tokens", 0))
+                finish_reason = str(metrics.get("finish_reason", "stop"))
+                if finish_reason == "max_tokens":
+                    finish_reason = "length"
+                yield GenerationChunk(
+                    delta="",
+                    text=event.text,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=len(event.generated_tokens),
+                    finish_reason=finish_reason,
+                    finished=True,
+                )
+            else:
+                yield GenerationChunk(
+                    delta=event.delta,
+                    text=event.text,
+                    completion_tokens=len(event.generated_tokens),
+                )
+
 
 @dataclass
 class ServerConfig:
@@ -192,6 +282,18 @@ def make_handler(config: ServerConfig):
             self.send_header("Content-Length", str(len(encoded)))
             self.end_headers()
             self.wfile.write(encoded)
+
+        def _send_sse_headers(self) -> None:
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.end_headers()
+
+        def _write_sse(self, payload: dict[str, Any] | str) -> None:
+            data = payload if isinstance(payload, str) else json.dumps(payload)
+            self.wfile.write(f"data: {data}\n\n".encode("utf-8"))
+            self.wfile.flush()
 
         def _read_json(self) -> dict[str, Any]:
             length = int(self.headers.get("Content-Length", "0"))
@@ -215,27 +317,103 @@ def make_handler(config: ServerConfig):
                 return
             self._send_json(HTTPStatus.NOT_FOUND, {"error": {"message": "Not found", "type": "not_found_error"}})
 
+        def _send_streaming_chat(
+            self,
+            *,
+            prompt: str,
+            model: str,
+            max_new_tokens: int,
+            temperature: float,
+        ) -> None:
+            chunk_id = f"chatcmpl-{uuid.uuid4().hex}"
+            created = int(time.time())
+            self._send_sse_headers()
+            self._write_sse(
+                build_chat_stream_chunk(
+                    chunk_id=chunk_id,
+                    created=created,
+                    model=model,
+                    delta={"role": "assistant"},
+                )
+            )
+
+            final_chunk: GenerationChunk | None = None
+            try:
+                for chunk in config.runner.stream(
+                    prompt=prompt,
+                    max_new_tokens=max_new_tokens,
+                    temperature=temperature,
+                ):
+                    if chunk.finished:
+                        final_chunk = chunk
+                        continue
+                    if not chunk.delta:
+                        continue
+                    self._write_sse(
+                        build_chat_stream_chunk(
+                            chunk_id=chunk_id,
+                            created=created,
+                            model=model,
+                            delta={"content": chunk.delta},
+                        )
+                    )
+                if final_chunk is None:
+                    raise RuntimeError("Streaming generation did not produce a final chunk.")
+                usage = {
+                    "prompt_tokens": final_chunk.prompt_tokens,
+                    "completion_tokens": final_chunk.completion_tokens,
+                    "total_tokens": final_chunk.prompt_tokens + final_chunk.completion_tokens,
+                }
+                self._write_sse(
+                    build_chat_stream_chunk(
+                        chunk_id=chunk_id,
+                        created=created,
+                        model=model,
+                        delta={},
+                        finish_reason=final_chunk.finish_reason or "stop",
+                        usage=usage,
+                    )
+                )
+            except Exception as exc:  # pragma: no cover - sent after headers
+                self._write_sse(
+                    {
+                        "error": {
+                            "message": str(exc),
+                            "type": "server_error",
+                        }
+                    }
+                )
+            finally:
+                self._write_sse("[DONE]")
+
         def do_POST(self) -> None:
             if self.path != "/v1/chat/completions":
                 self._send_json(HTTPStatus.NOT_FOUND, {"error": {"message": "Not found", "type": "not_found_error"}})
                 return
             try:
                 payload = self._read_json()
-                if payload.get("stream"):
-                    raise ValueError("Streaming is not supported by this server yet.")
                 messages = payload.get("messages")
                 if not isinstance(messages, list):
                     raise ValueError("'messages' must be a list.")
                 prompt = messages_to_prompt(messages)
+                model = str(payload.get("model") or config.model_id)
                 max_new_tokens = int(payload.get("max_tokens", 256))
                 temperature = float(payload.get("temperature", 0.0))
+                if payload.get("stream"):
+                    self._send_streaming_chat(
+                        prompt=prompt,
+                        model=model,
+                        max_new_tokens=max_new_tokens,
+                        temperature=temperature,
+                    )
+                    return
                 generation = config.runner.generate(
                     prompt=prompt,
                     max_new_tokens=max_new_tokens,
                     temperature=temperature,
                 )
                 response = build_chat_response(
-                    model=str(payload.get("model") or config.model_id),
+                    model=model,
                     content=generation.text,
                     prompt_tokens=generation.prompt_tokens,
                     completion_tokens=generation.completion_tokens,

--- a/dflash_mlx/runtime.py
+++ b/dflash_mlx/runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from dataclasses import dataclass
 import time
 from typing import Any
 
@@ -7,6 +9,14 @@ import mlx.core as mx
 
 from .adapters import LoadedTargetModel
 from .draft import DFlashDraftModel
+
+
+@dataclass
+class DFlashRuntimeEvent:
+    token_ids: list[int]
+    output_tokens: list[int]
+    metrics: dict[str, Any] | None = None
+    finished: bool = False
 
 
 def sample_tokens(logits: mx.array, temperature: float) -> mx.array:
@@ -347,7 +357,7 @@ def verify_block_chunked(
     raise RuntimeError("Chunked verifier reached an impossible state.")
 
 
-def dflash_generate(
+def dflash_generate_stream(
     target: LoadedTargetModel,
     draft: DFlashDraftModel,
     prompt_tokens: mx.array,
@@ -359,7 +369,7 @@ def dflash_generate(
     verify_mode: str,
     verify_chunk_size: int,
     profile: bool = False,
-) -> tuple[list[int], dict[str, Any]]:
+) -> Iterator[DFlashRuntimeEvent]:
     target_cache = target.make_cache()
     draft_cache = draft.make_cache()
     profile_times: dict[str, float] | None = {} if profile else None
@@ -382,7 +392,15 @@ def dflash_generate(
 
     output_tokens = prompt_tokens.tolist() + [first_token]
     start = prompt_len
+    streamed_len = prompt_len
     acceptance_lengths: list[int] = []
+
+    if max_new_tokens > 0:
+        yield DFlashRuntimeEvent(
+            token_ids=output_tokens[streamed_len:],
+            output_tokens=list(output_tokens),
+        )
+        streamed_len = len(output_tokens)
 
     decode_start = time.perf_counter()
     while start < total_max_tokens:
@@ -479,12 +497,24 @@ def dflash_generate(
         )
 
         stop_idx = stop_position(output_tokens, prompt_len, stop_token_ids)
+        finished = False
         if stop_idx is not None:
             output_tokens = output_tokens[: stop_idx + 1]
-            break
+            finished = True
 
         if len(output_tokens) > total_max_tokens:
             output_tokens = output_tokens[:total_max_tokens]
+            finished = True
+
+        token_ids = output_tokens[streamed_len:]
+        if token_ids:
+            yield DFlashRuntimeEvent(
+                token_ids=token_ids,
+                output_tokens=list(output_tokens),
+            )
+            streamed_len = len(output_tokens)
+
+        if finished:
             break
 
     decode_time = time.perf_counter() - decode_start
@@ -517,4 +547,43 @@ def dflash_generate(
             "unattributed_decode_time_s": decode_time - profiled_time,
             "steps": len(acceptance_lengths),
         }
-    return output_tokens, metrics
+    yield DFlashRuntimeEvent(
+        token_ids=[],
+        output_tokens=list(output_tokens),
+        metrics=metrics,
+        finished=True,
+    )
+
+
+def dflash_generate(
+    target: LoadedTargetModel,
+    draft: DFlashDraftModel,
+    prompt_tokens: mx.array,
+    max_new_tokens: int,
+    temperature: float,
+    stop_token_ids: set[int],
+    layer_ids: list[int],
+    speculative_tokens: int | None,
+    verify_mode: str,
+    verify_chunk_size: int,
+    profile: bool = False,
+) -> tuple[list[int], dict[str, Any]]:
+    final_event: DFlashRuntimeEvent | None = None
+    for event in dflash_generate_stream(
+        target=target,
+        draft=draft,
+        prompt_tokens=prompt_tokens,
+        max_new_tokens=max_new_tokens,
+        temperature=temperature,
+        stop_token_ids=stop_token_ids,
+        layer_ids=layer_ids,
+        speculative_tokens=speculative_tokens,
+        verify_mode=verify_mode,
+        verify_chunk_size=verify_chunk_size,
+        profile=profile,
+    ):
+        if event.finished:
+            final_event = event
+    if final_event is None or final_event.metrics is None:
+        raise RuntimeError("DFlash generation did not produce a final event.")
+    return final_event.output_tokens, final_event.metrics

--- a/tests/test_openai_server.py
+++ b/tests/test_openai_server.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import json
-
 
 def test_server_module_importable_and_has_main():
     from dflash_mlx import openai_server
@@ -68,6 +66,31 @@ def test_build_chat_response_has_openai_shape():
         "prompt_tokens": 12,
         "completion_tokens": 4,
         "total_tokens": 16,
+    }
+
+
+def test_build_chat_stream_chunk_has_openai_shape():
+    from dflash_mlx.openai_server import build_chat_stream_chunk
+
+    payload = build_chat_stream_chunk(
+        chunk_id="chatcmpl-test",
+        created=123,
+        model="local/qwen-dflash",
+        delta={"content": "Hel"},
+    )
+
+    assert payload == {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "created": 123,
+        "model": "local/qwen-dflash",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": "Hel"},
+                "finish_reason": None,
+            }
+        ],
     }
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -14,10 +14,12 @@ def test_public_api_importable():
     expected = {
         "DFlashGenerator",
         "DFlashResult",
+        "DFlashStreamEvent",
         "DFlashDraftModel",
         "LoadedTargetModel",
         "adapter_for_model_type",
         "dflash_generate",
+        "dflash_generate_stream",
         "load_draft_model",
         "load_target_model",
         "longest_prefix_match",
@@ -50,5 +52,18 @@ def test_cli_verify_mode_choices_exclude_unsafe_modes():
             sys.argv = [module.__name__]
             args = module.parse_args()
             assert args.verify_mode == "parallel-replay"
+    finally:
+        sys.argv = saved_argv
+
+
+def test_cli_stream_flags_parse():
+    from dflash_mlx import chat_cli, cli
+
+    saved_argv = sys.argv
+    try:
+        for module in (cli, chat_cli):
+            sys.argv = [module.__name__, "--stream"]
+            args = module.parse_args()
+            assert args.stream is True
     finally:
         sys.argv = saved_argv

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import mlx.core as mx
+
+
+def test_generator_stream_from_tokens_decodes_incremental_deltas(monkeypatch):
+    from dflash_mlx.api import DFlashGenerator
+    from dflash_mlx.runtime import DFlashRuntimeEvent
+
+    def fake_dflash_generate_stream(**kwargs):
+        yield DFlashRuntimeEvent(token_ids=[1], output_tokens=[99, 1])
+        yield DFlashRuntimeEvent(token_ids=[2, 3], output_tokens=[99, 1, 2, 3])
+        yield DFlashRuntimeEvent(
+            token_ids=[],
+            output_tokens=[99, 1, 2, 3],
+            metrics={"num_input_tokens": 1, "num_output_tokens": 3},
+            finished=True,
+        )
+
+    class FakeTokenizer:
+        def decode(self, tokens, skip_special_tokens=False):
+            pieces = {1: "Hel", 2: "lo", 3: "!"}
+            return "".join(pieces[token] for token in tokens)
+
+    class FakeTarget:
+        model = object()
+        tokenizer = FakeTokenizer()
+
+        def stop_token_ids(self):
+            return set()
+
+    class FakeDraft:
+        target_layer_ids: list[int] = []
+
+    monkeypatch.setattr(
+        "dflash_mlx.api.dflash_generate_stream",
+        fake_dflash_generate_stream,
+    )
+    monkeypatch.setattr("dflash_mlx.api.wired_limit", lambda model: nullcontext())
+
+    generator = object.__new__(DFlashGenerator)
+    generator.target = FakeTarget()
+    generator.draft = FakeDraft()
+
+    events = list(
+        generator.stream_from_tokens(
+            mx.array([99], dtype=mx.uint32),
+            max_new_tokens=3,
+        )
+    )
+
+    assert [event.delta for event in events] == ["Hel", "lo!", ""]
+    assert events[-1].finished is True
+    assert events[-1].text == "Hello!"
+    assert events[-1].metrics == {"num_input_tokens": 1, "num_output_tokens": 3}


### PR DESCRIPTION
## Summary
- add a streaming runtime event path and public DFlashGenerator.stream API
- add --stream support to the batch and chat CLIs
- support OpenAI-compatible SSE chat completion chunks when stream=true
- document streaming usage and add tests for decoded deltas and chunk shape

Closes #1

Non-greedy distribution-correct sampling remains tracked separately in #6.

## Validation
- PYTHONPATH=. uv run pytest tests/ -q
- python -m compileall -q dflash_mlx